### PR TITLE
Refactor/audit log persister

### DIFF
--- a/server/api/dto/admin/request/audit_logs.go
+++ b/server/api/dto/admin/request/audit_logs.go
@@ -3,6 +3,7 @@ package request
 import "time"
 
 type ListAuditLogDto struct {
+	GetTenantDto
 	Page         int        `query:"page"`
 	PerPage      int        `query:"per_page"`
 	StartTime    *time.Time `query:"start_time"`

--- a/server/api/dto/admin/request/tenant.go
+++ b/server/api/dto/admin/request/tenant.go
@@ -26,7 +26,7 @@ func (dto *CreateTenantDto) ToModel() models.Tenant {
 }
 
 type GetTenantDto struct {
-	Id string `param:"tenant_id" validate:"required,uuid4"`
+	TenantId string `param:"tenant_id" validate:"required,uuid4"`
 }
 
 type UpdateTenantDto struct {

--- a/server/api/handler/admin/secrets.go
+++ b/server/api/handler/admin/secrets.go
@@ -28,7 +28,13 @@ func (s *SecretsHandler) listKeys(ctx echo.Context, isApiKey bool) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "unable to list keys").SetInternal(err)
 	}
 
-	tenant, err := s.findTenantByIdString(dto.Id)
+	err = ctx.Validate(&dto)
+	if err != nil {
+		ctx.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "unable to list keys").SetInternal(err)
+	}
+
+	tenant, err := s.findTenantByIdString(dto.TenantId)
 	if err != nil {
 		ctx.Logger().Error(err)
 		return err
@@ -60,7 +66,13 @@ func (s *SecretsHandler) createKey(ctx echo.Context, isApiKey bool) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "unable to create key").SetInternal(err)
 	}
 
-	tenant, err := s.findTenantByIdString(dto.Id)
+	err = ctx.Validate(&dto)
+	if err != nil {
+		ctx.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "unable to create key").SetInternal(err)
+	}
+
+	tenant, err := s.findTenantByIdString(dto.TenantId)
 	if err != nil {
 		ctx.Logger().Error(err)
 		return err
@@ -93,7 +105,13 @@ func (s *SecretsHandler) removeKey(ctx echo.Context, isApiKey bool) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "unable to remove key").SetInternal(err)
 	}
 
-	tenant, err := s.findTenantByIdString(dto.Id)
+	err = ctx.Validate(&dto)
+	if err != nil {
+		ctx.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "unable to remove key").SetInternal(err)
+	}
+
+	tenant, err := s.findTenantByIdString(dto.TenantId)
 	if err != nil {
 		ctx.Logger().Error(err)
 		return err

--- a/server/api/router/admin.go
+++ b/server/api/router/admin.go
@@ -31,6 +31,9 @@ func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometh
 		rootGroup.Use(passkeyMiddleware.LoggerMiddleware())
 	}
 
+	// add CORS for all
+	main.Use(middleware.CORS())
+
 	// Validator
 	main.Validator = validators.NewCustomValidator()
 

--- a/server/persistence/models/audit_log.go
+++ b/server/persistence/models/audit_log.go
@@ -16,7 +16,7 @@ type AuditLog struct {
 	ActorUserId       *string      `db:"actor_user_id" json:"actor_user_id,omitempty"`
 	CreatedAt         time.Time    `db:"created_at" json:"created_at"`
 	UpdatedAt         time.Time    `db:"updated_at" json:"updated_at"`
-	Tenant            *Tenant      `json:"tenant" belongs_to:"tenants"`
+	Tenant            *Tenant      `json:"-" belongs_to:"tenants"`
 	TenantID          uuid.UUID    `json:"tenant_id" db:"tenant_id"`
 }
 

--- a/spec/passkey-server-admin.yaml
+++ b/spec/passkey-server-admin.yaml
@@ -533,12 +533,6 @@ components:
           schema:
             type: object
             properties:
-              type:
-                type:
-                  - string
-                  - 'null'
-                examples:
-                  - 'http://link-to-documentation'
               title:
                 type:
                   - string

--- a/spec/passkey-server-admin.yaml
+++ b/spec/passkey-server-admin.yaml
@@ -35,6 +35,8 @@ paths:
                 uniqueItems: true
                 items:
                   $ref: '#/components/schemas/tenant_list'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -55,6 +57,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/tenant_api_key'
+        '400':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -76,6 +82,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/tenant'
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -94,6 +106,12 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -110,6 +128,12 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -142,6 +166,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/secret'
                 description: The created secret
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -162,6 +192,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/secret_list'
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -194,6 +230,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/secret'
                 description: The created secret
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -214,6 +256,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/secret_list'
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -232,6 +280,12 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -250,6 +304,12 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -269,6 +329,140 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/error'
+        '404':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
+      servers:
+        - url: 'http://{host}:8001/{path_prefix}'
+          variables:
+            host:
+              default: localhost
+            path_prefix:
+              default: ''
+  '/tenants/{tenant_id}/audit_logs':
+    get:
+      summary: List audit log entries
+      description: Get a list of audit logs for a specific tenant
+      operationId: get-tenants-tenant_id-audit_logs
+      parameters:
+        - name: page
+          in: query
+          description: Page to start from
+          schema:
+            type: number
+            default: 1
+        - name: per_page
+          in: query
+          description: How many logs should be displayed per page
+          schema:
+            type: number
+            default: 20
+        - name: start_time
+          in: query
+          description: timestamp from where to start the list
+          schema:
+            type: string
+            format: date-time
+        - name: end_time
+          in: query
+          description: timestamp on which to end the list
+          schema:
+            type: string
+            format: date-time
+        - name: type
+          in: query
+          description: comma separated list of types to query for
+          schema:
+            type: string
+        - name: actor_user_id
+          in: query
+          description: id of the user who performed the action
+          schema:
+            type: string
+        - name: meta_source_ip
+          in: query
+          description: ip address from which the action was performed
+          schema:
+            type: string
+        - name: q
+          in: query
+          description: the search string
+          schema:
+            type: string
+        - $ref: '#/components/parameters/tenant_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/audit_log'
+          headers:
+            Link:
+              schema:
+                type: string
+              description: links to pages
+            X-Total-Count:
+              schema:
+                type: number
+              description: Total number of log entries
+        '400':
+          $ref: '#/components/responses/error'
+        '500':
+          $ref: '#/components/responses/error'
+      servers:
+        - url: 'http://{host}:8001/{path_prefix}'
+          variables:
+            host:
+              default: localhost
+            path_prefix:
+              default: ''
+  /health/alive:
+    get:
+      summary: Get alive status
+      description: Checks if the API is alive
+      operationId: get-health
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alive:
+                    type: boolean
+                required:
+                  - alive
+      servers:
+        - url: 'http://{host}:8001/{path_prefix}'
+          variables:
+            host:
+              default: localhost
+            path_prefix:
+              default: ''
+  /health/ready:
+    get:
+      summary: Get ready status
+      description: Checks if the API is ready for usage
+      operationId: get-health-ready
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ready:
+                    type: boolean
+                required:
+                  - ready
       servers:
         - url: 'http://{host}:8001/{path_prefix}'
           variables:
@@ -331,6 +525,36 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/config'
+  responses:
+    error:
+      description: Error Response with detailed information
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              type:
+                type:
+                  - string
+                  - 'null'
+                examples:
+                  - 'http://link-to-documentation'
+              title:
+                type:
+                  - string
+                  - 'null'
+                examples:
+                  - explanatory title
+              details:
+                type:
+                  - string
+                  - 'null'
+                examples:
+                  - Information which helps resolving the problem
+              status:
+                type:
+                  - integer
+                  - 'null'
   schemas:
     tenant_list:
       type: object
@@ -461,7 +685,6 @@ components:
         icon:
           type:
             - string
-            - 'null'
           format: uri
           examples:
             - 'http://link.to/icon'
@@ -480,3 +703,40 @@ components:
       uniqueItems: true
       items:
         $ref: '#/components/schemas/secret'
+    audit_log:
+      type: object
+      title: audit_log
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+        error:
+          type: string
+        meta_http_request_id:
+          type: string
+        meta_source_ip:
+          type: string
+        meta_user_agent:
+          type: string
+        actor_user_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        tenant_id:
+          type: string
+          format: uuid
+      required:
+        - id
+        - type
+        - meta_http_request_id
+        - meta_source_ip
+        - meta_user_agent
+        - created_at
+        - updated_at
+        - tenant_id

--- a/spec/passkey-server-admin.yaml
+++ b/spec/passkey-server-admin.yaml
@@ -549,6 +549,10 @@ components:
                 type:
                   - integer
                   - 'null'
+              additional:
+                type:
+                  - object
+                  - 'null'
   schemas:
     tenant_list:
       type: object
@@ -677,8 +681,7 @@ components:
           examples:
             - Hanko Passkey Server
         icon:
-          type:
-            - string
+          type: string
           format: uri
           examples:
             - 'http://link.to/icon'

--- a/spec/passkey-server.yaml
+++ b/spec/passkey-server.yaml
@@ -414,12 +414,6 @@ components:
           schema:
             type: object
             properties:
-              type:
-                type:
-                  - string
-                  - 'null'
-                examples:
-                  - 'http://link-to-documentation'
               title:
                 type:
                   - string
@@ -435,6 +429,10 @@ components:
               status:
                 type:
                   - integer
+                  - 'null'
+              additional:
+                type:
+                  - object
                   - 'null'
     post-registration-initialize:
       description: Example response


### PR DESCRIPTION
This PR adds tenant_id to and removes unused email field from audit_log filters.

the PR also adds missing validation for DTOs (especially for TenantId) and adds missing endpoints and error responses to the admin spec.

Related to #14, #15 